### PR TITLE
PF-133 Implemented mapping of eHSN level notes to LevelSurvey

### DIFF
--- a/src/EhsnPlugin/DataModel/ParsedEhsnLevelSurvey.cs
+++ b/src/EhsnPlugin/DataModel/ParsedEhsnLevelSurvey.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace EhsnPlugin.DataModel
+{
+    public class ParsedEhsnLevelSurvey
+    {
+        public IReadOnlyList<EHSNLevelNotesLevelChecksLevelChecksTable> LevelCheckTables { get; set; }
+        public IReadOnlyList<EHSNLevelNotesLevelChecksSummaryTableRow> LevelSummaryRows { get; set; }
+        public string LevelCheckComments { get; set; }
+        public string Party { get; set; }
+
+        public ParsedEhsnLevelSurvey(EHSNLevelNotesLevelChecksLevelChecksTable[] levelChecksTables, 
+            EHSNLevelNotesLevelChecksSummaryTableRow[] summaryTableRows)
+        {
+            LevelCheckTables = levelChecksTables == null
+                ? new List<EHSNLevelNotesLevelChecksLevelChecksTable>()
+                : new List<EHSNLevelNotesLevelChecksLevelChecksTable>(levelChecksTables);
+
+            LevelSummaryRows = summaryTableRows == null
+                ? new List<EHSNLevelNotesLevelChecksSummaryTableRow>()
+                : new List<EHSNLevelNotesLevelChecksSummaryTableRow>(summaryTableRows);
+        }
+    }
+}

--- a/src/EhsnPlugin/EhsnPlugin.csproj
+++ b/src/EhsnPlugin/EhsnPlugin.csproj
@@ -32,8 +32,8 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FieldDataPluginFramework, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\Aquarius.FieldDataFramework.1.0.1\lib\net47\FieldDataPluginFramework.dll</HintPath>
+    <Reference Include="FieldDataPluginFramework, Version=1.1.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\Aquarius.FieldDataFramework.18.1.2\lib\net47\FieldDataPluginFramework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -46,9 +46,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DataModel\ParsedEhsnLevelSurvey.cs" />
     <Compile Include="DataModel\EhsnMeasurement.cs" />
     <Compile Include="DataModel\MeasurementRecord.cs" />
+    <Compile Include="Exceptions\EHsnPluginException.cs" />
     <Compile Include="Helpers\TimeHelper.cs" />
+    <Compile Include="Mappers\LevelSurveyMapper.cs" />
     <Compile Include="Mappers\ReadingMapper.cs" />
     <Compile Include="Mappers\DischargeActivityMapper.cs" />
     <Compile Include="Mappers\MeasurementParser.cs" />
@@ -76,6 +79,6 @@
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)packages\Aquarius.FieldDataFramework.1.0.1\tools\PluginPackager.exe $(TargetPath) /OutputPath=$(ProjectDir)deploy\$(Configuration)\$(TargetName).plugin</PostBuildEvent>
+    <PostBuildEvent>$(SolutionDir)packages\Aquarius.FieldDataFramework.18.1.2\tools\PluginPackager.exe $(TargetPath) /OutputPath=$(ProjectDir)deploy\$(Configuration)\$(TargetName).plugin</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/EhsnPlugin/Exceptions/EHsnPluginException.cs
+++ b/src/EhsnPlugin/Exceptions/EHsnPluginException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace EhsnPlugin.Exceptions
+{
+    public class EHsnPluginException : Exception
+    {
+        public EHsnPluginException()
+        {
+        }
+
+        public EHsnPluginException(string message) : base(message)
+        {
+        }
+
+        public EHsnPluginException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected EHsnPluginException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/EhsnPlugin/Helpers/TimeHelper.cs
+++ b/src/EhsnPlugin/Helpers/TimeHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 
 namespace EhsnPlugin.Helpers
 {
@@ -17,6 +18,22 @@ namespace EhsnPlugin.Helpers
                 0);
 
             return meanTime < start ? start : meanTime;
+        }
+
+        public static DateTime ParseTimeOrMinValue(string timeString, DateTime visitDate)
+        {
+            if (string.IsNullOrWhiteSpace(timeString) ||
+                !Regex.IsMatch(timeString, @"^\d{2}:\d{2}(:\d{2}){0,1}$"))
+            {
+                return DateTime.MinValue;
+            }
+
+            var parts = timeString.Split(':');
+            var hour = Int32.Parse(parts[0]);
+            var minute = Int32.Parse(parts[1]);
+            var second = parts.Length == 3 ? Int32.Parse(parts[2]) : 0;
+
+            return new DateTime(visitDate.Year, visitDate.Month, visitDate.Day, hour, minute, second);
         }
     }
 }

--- a/src/EhsnPlugin/Mappers/FieldVisitMapper.cs
+++ b/src/EhsnPlugin/Mappers/FieldVisitMapper.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using EhsnPlugin.DataModel;
+using FieldDataPluginFramework;
 using FieldDataPluginFramework.Context;
 using FieldDataPluginFramework.DataModel;
 using FieldDataPluginFramework.DataModel.DischargeActivities;
+using FieldDataPluginFramework.DataModel.LevelSurveys;
 using FieldDataPluginFramework.DataModel.Readings;
 
 namespace EhsnPlugin.Mappers
@@ -16,11 +18,13 @@ namespace EhsnPlugin.Mappers
         private readonly LocationInfo _locationInfo;
         private readonly EhsnMeasurement _ehsnMeasurement;
         private readonly DateTime _visitDate;
-        
-        public FieldVisitMapper(EHSN eHsn, LocationInfo locationInfo)
+        private readonly ILog _logger;
+
+        public FieldVisitMapper(EHSN eHsn, LocationInfo locationInfo, ILog logger)
         {
             _eHsn = eHsn ?? throw new ArgumentNullException(nameof(eHsn));
-            _locationInfo = locationInfo;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _locationInfo = locationInfo ?? throw new ArgumentNullException(nameof(locationInfo));
 
             _visitDate = GetVisitDate(eHsn.GenInfo);
 
@@ -79,6 +83,11 @@ namespace EhsnPlugin.Mappers
         public IEnumerable<Reading> MapReadings()
         {
             return new ReadingMapper(_ehsnMeasurement).Map();
+        }
+
+        public LevelSurvey MapLevelSurveyOrNull()
+        {
+            return new LevelSurveyMapper(_locationInfo, _visitDate, _logger).MapOrNull(_eHsn);
         }
     }
 }

--- a/src/EhsnPlugin/Mappers/LevelSurveyMapper.cs
+++ b/src/EhsnPlugin/Mappers/LevelSurveyMapper.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using EhsnPlugin.DataModel;
+using EhsnPlugin.Exceptions;
+using EhsnPlugin.Helpers;
+using FieldDataPluginFramework;
+using FieldDataPluginFramework.Context;
+using FieldDataPluginFramework.DataModel.LevelSurveys;
+
+namespace EhsnPlugin.Mappers
+{
+    public class LevelSurveyMapper
+    {
+        private readonly ILog _logger;
+
+        private readonly LocationInfo _locationInfo;
+        private readonly DateTime _visitDateTime;
+
+        public LevelSurveyMapper(LocationInfo locationInfo, DateTime visitDate, ILog logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _locationInfo = locationInfo ?? throw new ArgumentNullException(nameof(locationInfo));
+
+            _visitDateTime = visitDate;
+        }
+
+        private ParsedEhsnLevelSurvey ParseLevelSurveyInfo(EHSN eHsn)
+        {
+            return new ParsedEhsnLevelSurvey(eHsn.LevelNotes?.LevelChecks?.LevelChecksTable,
+                           eHsn.LevelNotes?.LevelChecks?.LevelChecksSummaryTable)
+            {
+                LevelCheckComments = eHsn.LevelNotes?.LevelChecks?.comments,
+                Party = eHsn.PartyInfo.party
+            };
+        }
+
+        private bool HasLevelSurvey(ParsedEhsnLevelSurvey parsedItem)
+        {
+            return parsedItem.LevelSummaryRows.Any() &&
+                   parsedItem.LevelCheckTables.Any();
+        }
+
+        public LevelSurvey MapOrNull(EHSN eHsn)
+        {
+            if (eHsn == null) throw new ArgumentNullException(nameof(eHsn));
+
+            var parsedSurvey = ParseLevelSurveyInfo(eHsn);
+
+            if (!HasLevelSurvey(parsedSurvey))
+            {
+                return null;
+            }
+
+            Validate(parsedSurvey);
+
+            return ToLevelSurvey(parsedSurvey);
+        }
+
+        private void Validate(ParsedEhsnLevelSurvey parsedEhsnLevelSurvey)
+        {
+            var levelSummaryRows = parsedEhsnLevelSurvey.LevelSummaryRows;
+
+            foreach (var row in levelSummaryRows)
+            {
+                if (string.IsNullOrWhiteSpace(row.reference))
+                {
+                    throw new EHsnPluginException("Invalid SummaryTableRow: 'reference' cannot be null or empty.");
+                }
+
+                if (string.IsNullOrWhiteSpace(row.time) ||
+                    TimeHelper.ParseTimeOrMinValue(row.time, _visitDateTime.Date) == DateTime.MinValue)
+                {
+                    throw new EHsnPluginException($"Invalid SummaryTableRow: time is invalid {row.time}.");
+                }
+            }
+        }
+
+        private LevelSurvey ToLevelSurvey(ParsedEhsnLevelSurvey parsedEhsnLevelSurvey)
+        {
+            var originReferenceName = GetFirstReferenceInSummaryTableAsOriginReferenceName(
+                parsedEhsnLevelSurvey.LevelSummaryRows);
+
+            var levelSurveyMeasurements = GetLevelSurveyMeasurements(parsedEhsnLevelSurvey).ToList();
+
+            return new LevelSurvey(originReferenceName)
+            {
+                Comments = parsedEhsnLevelSurvey.LevelCheckComments,
+                LevelSurveyMeasurements = levelSurveyMeasurements,
+                Party = parsedEhsnLevelSurvey.Party
+            };
+        }
+
+        private string GetFirstReferenceInSummaryTableAsOriginReferenceName(
+            IReadOnlyList<EHSNLevelNotesLevelChecksSummaryTableRow> levelSummaryRows)
+        {
+            return levelSummaryRows.First().reference;
+        }
+
+        private IEnumerable<LevelSurveyMeasurement> GetLevelSurveyMeasurements(
+            ParsedEhsnLevelSurvey parsedEhsnLevelSurvey)
+        {
+            var levelMeasurements = new List<LevelSurveyMeasurement>();
+
+            var levelSummaryRows = parsedEhsnLevelSurvey.LevelSummaryRows;
+            var checkTables = parsedEhsnLevelSurvey.LevelCheckTables;
+
+            var referenceGroupedRows = levelSummaryRows.GroupBy(row => row.reference);
+
+            foreach (var summaryRows in referenceGroupedRows)
+            {
+                var reference = summaryRows.Key;
+                var summaryRowList = summaryRows.ToList();
+                if (summaryRowList.Count > 1)
+                {
+                    _logger.Error($"{reference} has multiple summary rows. Only first one is used.");
+                }
+
+                var summaryRow = summaryRowList.First();
+
+                var time = TimeHelper.ParseTimeOrMinValue(summaryRow.time, _visitDateTime);
+                var timeOffset = new DateTimeOffset(time, _locationInfo.UtcOffset);
+
+                var measuredElevation = GetAveragedMeasuredElevation(reference, checkTables);
+
+                var measurement = new LevelSurveyMeasurement(reference, timeOffset, measuredElevation)
+                {
+                    Comments = GetCombinedRemarks(reference, checkTables)
+                };
+
+                levelMeasurements.Add(measurement);
+            }
+
+            return levelMeasurements;
+        }
+
+        private double GetAveragedMeasuredElevation(string reference,
+            IReadOnlyList<EHSNLevelNotesLevelChecksLevelChecksTable> checkTables)
+        {
+            var allCheckRows = GetCheckRows(reference, checkTables).ToList();
+
+            if (!allCheckRows.Any())
+            {
+                throw new EHsnPluginException("Not enough level check rows to determine the elevation " +
+                                              $"for {reference}.");
+            }
+
+            var allElevationSum = allCheckRows.Select(row => row.elevation).Sum();
+
+            return (double)allElevationSum / allCheckRows.Count;
+        }
+
+        private string GetCombinedRemarks(string reference,
+            IReadOnlyList<EHSNLevelNotesLevelChecksLevelChecksTable> checkTables)
+        {
+            var allRemarks = GetCheckRows(reference, checkTables)
+                .Select(row => row.comments)
+                .Where(r => !string.IsNullOrWhiteSpace(r))
+                .ToList();
+
+            return allRemarks.Any()
+                ? string.Join("\n", allRemarks)
+                : string.Empty;
+        }
+
+        private IEnumerable<EHSNLevelNotesLevelChecksLevelChecksTableLevelChecksRow> GetCheckRows(
+            string reference, IReadOnlyList<EHSNLevelNotesLevelChecksLevelChecksTable> checkTables)
+        {
+            return checkTables == null
+                ? new List<EHSNLevelNotesLevelChecksLevelChecksTableLevelChecksRow>()
+                : checkTables.Where(t => t.LevelChecksRow != null)
+                                    .SelectMany(t => t.LevelChecksRow)
+                                    .Where(row => string.Equals(row.station, reference, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/EhsnPlugin/Mappers/MeasurementParser.cs
+++ b/src/EhsnPlugin/Mappers/MeasurementParser.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using EhsnPlugin.DataModel;
 using EhsnPlugin.Helpers;
 using EhsnPlugin.SystemCode;
@@ -51,6 +50,11 @@ namespace EhsnPlugin.Mappers
             return TimeHelper.GetMeanTimeTruncatedToMinute(start, end);
         }
 
+        private DateTime ParseTimeOrMinValue(string timeString)
+        {
+            return TimeHelper.ParseTimeOrMinValue(timeString, _visitDate);
+        }
+
         private List<MeasurementRecord> ParseStageMeasurements()
         {
             var measurements = new List<MeasurementRecord>();
@@ -81,22 +85,6 @@ namespace EhsnPlugin.Mappers
             return row.SRC.HasValue
                 ? $"@{row.time} {row.SRCApp}. Correction:{row.SRC.Value}"
                 : string.Empty;
-        }
-
-        private DateTime ParseTimeOrMinValue(string timeString)
-        {
-            if (string.IsNullOrWhiteSpace(timeString) ||
-                !Regex.IsMatch(timeString, @"^\d{2}:\d{2}(:\d{2}){0,1}$"))
-            {
-                return DateTime.MinValue;
-            }
-
-            var parts = timeString.Split(':');
-            var hour = Int32.Parse(parts[0]);
-            var minute = Int32.Parse(parts[1]);
-            var second = parts.Length == 3 ? Int32.Parse(parts[2]) : 0;
-
-            return new DateTime(_visitDate.Year, _visitDate.Month, _visitDate.Day, hour, minute, second);
         }
 
         private List<MeasurementRecord> ParseDischargeMeasurements()

--- a/src/EhsnPlugin/Parser.cs
+++ b/src/EhsnPlugin/Parser.cs
@@ -56,7 +56,7 @@ namespace EhsnPlugin
 
             var locationInfo = _appender.GetLocationByIdentifier(locationIdentifier);
 
-            var mapper = new FieldVisitMapper(eHsn, locationInfo);
+            var mapper = new FieldVisitMapper(eHsn, locationInfo, _logger);
 
             var fieldVisitInfo = AppendMappedFieldVisitInfo(mapper, locationInfo);
 
@@ -81,6 +81,12 @@ namespace EhsnPlugin
             foreach (var reading in readings)
             {
                 _appender.AddReading(fieldVisitInfo, reading);
+            }
+
+            var levelSurvey = mapper.MapLevelSurveyOrNull();
+            if(levelSurvey != null)
+            {
+                _appender.AddLevelSurvey(fieldVisitInfo, levelSurvey);
             }
         }
     }

--- a/src/EhsnPlugin/packages.config
+++ b/src/EhsnPlugin/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.FieldDataFramework" version="1.0.1" targetFramework="net47" />
+  <package id="Aquarius.FieldDataFramework" version="18.1.2" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
- Summary row and level check rows are not 1-1 relationship.
  We get the time in summary row, averaged elevation from level check rows.
- If multiple summary rows found for the same reference,
  only the first is used because field visit plugin framework does not
  support multiple measurements for same reference.