### PR TITLE
PF-275 - Update to framework 18.4.2

### DIFF
--- a/src/EhsnPlugin/EhsnPlugin.csproj
+++ b/src/EhsnPlugin/EhsnPlugin.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FieldDataPluginFramework, Version=2.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\Aquarius.FieldDataFramework.18.4.1\lib\net472\FieldDataPluginFramework.dll</HintPath>
+      <HintPath>..\packages\Aquarius.FieldDataFramework.18.4.2\lib\net472\FieldDataPluginFramework.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Text, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ServiceStack.Text.4.5.12\lib\net45\ServiceStack.Text.dll</HintPath>
@@ -88,6 +88,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions />
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)packages\Aquarius.FieldDataFramework.18.4.1\tools\PluginPackager.exe $(TargetPath) /OutputPath=$(ProjectDir)deploy\$(Configuration)\$(TargetName).plugin /Description="Imports eHSN XML files into AQTS field visits"</PostBuildEvent>
+    <PostBuildEvent>$(SolutionDir)packages\Aquarius.FieldDataFramework.18.4.2\tools\PluginPackager.exe $(TargetPath) /OutputPath=$(ProjectDir)deploy\$(Configuration)\$(TargetName).plugin /Description="Imports eHSN XML files into AQTS field visits"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/EhsnPlugin/packages.config
+++ b/src/EhsnPlugin/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.FieldDataFramework" version="18.4.1" targetFramework="net472" />
+  <package id="Aquarius.FieldDataFramework" version="18.4.2" targetFramework="net472" />
   <package id="ServiceStack.Text" version="4.5.12" targetFramework="net472" />
 </packages>

--- a/src/integrationTest.sh
+++ b/src/integrationTest.sh
@@ -4,10 +4,8 @@ Configuration=$1
 PluginTesterPath=$2
 
 [ ! -z "$Configuration" ] || Configuration=Debug
-[ ! -z "$PluginTesterPath" ] || PluginTesterPath=packages/Aquarius.FieldDataFramework.18.4.1/tools
+[ ! -z "$PluginTesterPath" ] || PluginTesterPath=packages/Aquarius.FieldDataFramework.18.4.2/tools
 
 mkdir -p ../results
 
-for f in ../data/*.xml; do
-	$PluginTesterPath/PluginTester.exe -Plugin=EhsnPlugin/bin/$Configuration/EhsnPlugin.dll -Data=$f -Json=${f/\/data\///results/}.json >/dev/null && echo "GOOD: $f" || echo "ERROR: $f" `grep --max-count=1 ERROR $PluginTesterPath/PluginTester.log` | tee ${f/\/data\///results/}.error.log
-done
+$PluginTesterPath/PluginTester.exe -Plugin=EhsnPlugin/bin/$Configuration/EhsnPlugin.dll -Data=../data/*.xml -Json=../results


### PR DESCRIPTION
This allows the PluginTester to run more quickly on bulk directory tests.

The current plugin can process about 30 files per second when run in batch mode.