### PR TITLE
Issue-13 - Consolidate all level checks into a single level survey activity

### DIFF
--- a/src/EhsnPlugin/Parser.cs
+++ b/src/EhsnPlugin/Parser.cs
@@ -92,7 +92,7 @@ namespace EhsnPlugin
         {
             var fieldVisitDetails = mapper.MapFieldVisitDetails();
 
-            _logger.Info($"Successfully parsed one visit '{fieldVisitDetails.FieldVisitPeriod}' for location '{locationInfo.LocationIdentifier}'");
+            _logger.Info($"Successfully parsed one visit '{fieldVisitDetails.FieldVisitPeriod.Start:O}/{fieldVisitDetails.FieldVisitPeriod.End:O}' for location '{locationInfo.LocationIdentifier}'");
 
             return _appender.AddFieldVisit(locationInfo, fieldVisitDetails);
         }


### PR DESCRIPTION
Also delay calculating the level survey time until needed. This will avoid any "Can't calculate mean gauge height time" exceptions.

Added some logging for when a reference point elevation is measured more than once with different results.

Now all the supplied EHSN files are passing.