### PR TITLE
Plugin modification for EHSN 2.0.0

### DIFF
--- a/src/EhsnPlugin/Config.cs
+++ b/src/EhsnPlugin/Config.cs
@@ -6,7 +6,7 @@ namespace EhsnPlugin
     public class Config
     {
         public string MinVersion { get; set; } = "v1.3";
-        public string MaxVersion { get; set; } = "v1.3.2";
+        public string MaxVersion { get; set; } = "v2.0.0";
         public string DefaultChannelName { get; set; } = ChannelMeasurementBaseConstants.DefaultChannelName;
         public string UnknownMeterPlaceholder { get; set; } = "Unknown";
         public string StageWaterLevelMethodCode { get; set; }

--- a/src/EhsnPlugin/Config.json
+++ b/src/EhsnPlugin/Config.json
@@ -1,6 +1,6 @@
 ﻿{
   "MinVersion": "v1.3",
-  "MaxVersion": "v1.3.2",
+  "MaxVersion": "v2.0.0",
   "DefaultChannelName": "Main",
   "UnknownMeterPlaceholder": "Unknown",
   "StageWaterLevelMethodCode": "HGDWL",

--- a/src/EhsnPlugin/Mappers/FieldVisitMapper.cs
+++ b/src/EhsnPlugin/Mappers/FieldVisitMapper.cs
@@ -105,6 +105,12 @@ namespace EhsnPlugin.Mappers
                 .Append(ExtractTime(_eHsn.MovingBoatMeas?.ADCPMeasResults?.mmntStartTime))
                 .Append(ExtractTime(_eHsn.MovingBoatMeas?.ADCPMeasResults?.mmntEndTime))
                 .Append(ExtractTime(_eHsn.MovingBoatMeas?.ADCPMeasResults?.mmntMeanTime))
+                .Append(ExtractTime(_eHsn.EnvCond?.gasArrTime))
+                .Append(ExtractTime(_eHsn.EnvCond?.gasDepTime))
+                .Append(ExtractTime(_eHsn.EnvCond?.feedArrTime))
+                .Append(ExtractTime(_eHsn.EnvCond?.feedDepTime))
+                .Append(ExtractTime(_eHsn.EnvCond?.bpmrotArrTime))
+                .Append(ExtractTime(_eHsn.EnvCond?.bpmrotDepTime))
                 .Where(d => d != DateTimeOffset.MinValue)
                 .OrderBy(dateTimeOffset => dateTimeOffset)
                 .ToList();

--- a/src/EhsnPlugin/Mappers/ReadingMapper.cs
+++ b/src/EhsnPlugin/Mappers/ReadingMapper.cs
@@ -118,22 +118,10 @@ namespace EhsnPlugin.Mappers
         private void AddDischargeTemperatureReadings(List<Reading> readings)
         {
             if (_eHsn.DisMeas == null) return;
+            var readingtime = InferEnvironmentalConditionReadingTime();
 
-            DateTimeOffset? time = TimeHelper.ParseTimeOrMinValue(_eHsn.DisMeas.mmtTimeVal, VisitDate, LocationInfo.UtcOffset);
-
-            if (time == DateTimeOffset.MinValue)
-            {
-                var startTime = TimeHelper.ParseTimeOrMinValue(_eHsn.DisMeas.startTime, VisitDate, LocationInfo.UtcOffset);
-                var endTime = TimeHelper.ParseTimeOrMinValue(_eHsn.DisMeas.endTime, VisitDate, LocationInfo.UtcOffset);
-
-                time = TimeHelper.GetMeanTimeTruncatedToMinute(startTime, endTime);
-
-                if (time == DateTimeOffset.MinValue)
-                    time = null;
-            }
-
-            AddReading(readings, time, Parameters.WaterTemp, Units.TemperatureUnitId, _eHsn.DisMeas.waterTemp);
-            AddReading(readings, time, Parameters.AirTemp, Units.TemperatureUnitId, _eHsn.DisMeas.airTemp);
+            AddReading(readings, readingtime, Parameters.WaterTemp, Units.TemperatureUnitId, _eHsn.DisMeas.waterTemp);
+            AddReading(readings, readingtime, Parameters.AirTemp, Units.TemperatureUnitId, _eHsn.DisMeas.airTemp);
         }
 
         private void AddSensorReading(List<Reading> readings, EHSNMeasResultsSensorRef sensorRef)

--- a/src/EhsnPlugin/Validators/VersionValidator.cs
+++ b/src/EhsnPlugin/Validators/VersionValidator.cs
@@ -9,7 +9,7 @@ namespace EhsnPlugin.Validators
         private Version MinVersion { get; } = DefaultVersion;
         private Version MaxVersion { get; } = DefaultVersion;
 
-        private static readonly Version DefaultVersion = Version.Create("v1.3.2");
+        private static readonly Version DefaultVersion = Version.Create("v2.0.0");
 
         public VersionValidator(Config config)
         {


### PR DESCRIPTION
Hey Doug,
Here is a few changes I made to the plugin:

- Change the max version from 1.3.2 to 2.0.0. (since we want to call the next release eHSN V2.0.0)
- Add timestamp in environment conditional panel in the definition of the FV start and end time.
- For Air and Water temperature, if there is no discharge time, it will take the stage time. So it will also techs to upload air and water temperature if they did not do a discharge or stage measurement.

Thanks,
Xu
