### PR TITLE
Issue-46 - Avoid validation errors for DistanceToMeter exceeding SoundedDepth

### DIFF
--- a/src/EhsnPlugin/Mappers/DischargeActivityMapper.cs
+++ b/src/EhsnPlugin/Mappers/DischargeActivityMapper.cs
@@ -482,6 +482,15 @@ namespace EhsnPlugin.Mappers
             var waterSurfaceToBottomOfIce = panel.IceCovered?.WSToBottomOfIceAdjusted.ToNullableDouble() ?? 0;
             var waterSurfaceToBottomOfSlush = panel.IceCovered?.WaterSurfaceToBottomOfSlush.ToNullableDouble() ?? waterSurfaceToBottomOfIce;
 
+            string comments = null;
+            var distanceToMeter = panel.Open?.DistanceAboveWeight.ToNullableDouble();
+
+            if (distanceToMeter > soundedDepth)
+            {
+                comments = $"Original DistanceToMeter={distanceToMeter:F2} {Units.DistanceUnitId} updated to SoundedDepth={soundedDepth:F2} {Units.DistanceUnitId} by eHSN plugin.";
+                distanceToMeter = soundedDepth;
+            }
+
             var measurementCondition = panel.IceCovered != null
                 ? (MeasurementConditionData) new IceCoveredData
                 {
@@ -494,7 +503,7 @@ namespace EhsnPlugin.Mappers
                 }
                 : new OpenWaterData
                 {
-                    DistanceToMeter = panel.Open?.DistanceAboveWeight.ToNullableDouble(),
+                    DistanceToMeter = distanceToMeter,
                     DryLineAngle = panel.DryAngle.ToNullableDouble() ?? 0,
                     DryLineCorrection = panel.DryCorrection.ToNullableDouble(),
                     WetLineCorrection = panel.WetCorrection.ToNullableDouble(),
@@ -555,6 +564,7 @@ namespace EhsnPlugin.Mappers
             var vertical = new Vertical
             {
                 VerticalType = VerticalType.MidRiver,
+                Comments = comments,
                 MeasurementTime = TimeHelper.CoerceDateTimeIntoUtcOffset(panel.Date, LocationInfo.UtcOffset),
                 SequenceNumber = panel.panelId,
                 TaglinePosition = taglinePosition,


### PR DESCRIPTION
@yanxuYX This change will fix #46 and avoid the validation errors when DistanceToMeter exceeds the SoundedDepth.

The value of DistanceToMeter will be constrained to be no larger than SoundedDepth, and a comment will be added to any vertical where this constraint was applied by the plugin.
