### PR TITLE
Issue-50 - Prepare for AQTS 2020.2, to load the JSON configuration from global settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,28 @@ An AQTS field data plugin supporting eHSN (electronic Hydrometric Station Notes)
 
 ## Want to install this plugin?
 
-- Download the latest release of the plugin [here](../../releases/latest)
-- Install it using the [FieldVisitPluginTool](https://github.com/AquaticInformatics/aquarius-field-data-framework/tree/master/src/FieldDataPluginTool)
-- 
+- Install it on AQTS 2019.2-or-newer via the System Configuration page
+
+### Plugin Compatibility Matrix
+
+Choose the appropriate version of the plugin for your AQTS app server.
+
+| AQTS Version | Latest compatible plugin Version |
+| --- | --- |
+| AQTS 2020.2 | [v20.2.0](https://github.com/AquaticInformatics/eHSN-field-data-plugin/releases/download/v20.2.0/EhsnPlugin.plugin) |
+| AQTS 2020.1<br/>AQTS 2019.4<br/>AQTS 2019.3<br/>AQTS 2019.2 | [v19.2.22](https://github.com/AquaticInformatics/eHSN-field-data-plugin/releases/download/v19.2.22/EhsnPlugin.plugin) |
+
+## Configuring the plugin
+
+The plugin can be configured via a [`Config.json`](./src/EhsnPlugin/Config.json) JSON document, to control the mapping of eHSN values to your AQTS app server.
+
+The JSON configuration is stored in different places, depending on the version of the plugin.
+
+| Version | Configuration location |
+| --- | --- |
+| 20.2.x | Use the Settings page of the System Config app to change the settings.<br/><br/>**Group**: `FieldDataPluginConfig-EhsnPlugin`<br/>**Key**: `Config`<br/>**Value**: The entire contents of the Config.json file. If blank or omitted, the plugin's default [`Config.json`](./src/EhsnPlugin/Config.json) is used. |
+| 19.2.x | Read from the `Config.json` file in the plugin folder, at `%ProgramData%\Aquatic Informatics\AQUARIUS Server\FieldDataPlugins\EhsnPlugin\Config.json` |
+
 ## Building the plugin
 
 - Load the `src\eHSN.sln` file in Visual Studio and build the `Release` configuration.
@@ -25,7 +44,7 @@ Use the included `PluginTester.exe` tool from the `Aquarius.FieldDataFrame` pack
 
 1. Open the EhsnPlugin project's **Properties** page
 2. Select the **Debug** tab
-3. Select **Start external program:** as the start action and browse to `"src\packages\Aquarius.FieldDataFramework.18.4.1\tools\PluginTester.exe`
+3. Select **Start external program:** as the start action and browse to `"src\packages\Aquarius.FieldDataFramework.20.2.0\tools\PluginTester.exe`
 4. Enter the **Command line arguments:** to launch your plugin
 
 ```
@@ -39,7 +58,3 @@ The `/Plugin=` argument can be the filename of your plugin assembly, without any
 7. Now you're debugging your plugin!
 
 See the [PluginTester](https://github.com/AquaticInformatics/aquarius-field-data-framework/tree/master/src/PluginTester) documentation for more details.
-
-## Installation of the plugin
-
-Use the [FieldDataPluginTool](https://github.com/AquaticInformatics/aquarius-field-data-framework/tree/master/src/FieldDataPluginTool) to install the plugin on your AQTS app server.

--- a/README.md
+++ b/README.md
@@ -19,12 +19,16 @@ Choose the appropriate version of the plugin for your AQTS app server.
 
 | AQTS Version | Latest compatible plugin Version |
 | --- | --- |
-| AQTS 2020.2 | [v20.2.0](https://github.com/AquaticInformatics/eHSN-field-data-plugin/releases/download/v20.2.0/EhsnPlugin.plugin) |
-| AQTS 2020.1<br/>AQTS 2019.4<br/>AQTS 2019.3<br/>AQTS 2019.2 | [v19.2.22](https://github.com/AquaticInformatics/eHSN-field-data-plugin/releases/download/v19.2.22/EhsnPlugin.plugin) |
+| AQTS 2020.3+ | [v20.3.0](https://github.com/AquaticInformatics/eHSN-field-data-plugin/releases/download/v20.3.0/EhsnPlugin.plugin) |
+| AQTS 2020.2<br/>AQTS 2020.1<br/>AQTS 2019.4<br/>AQTS 2019.3<br/>AQTS 2019.2 | [v19.2.22](https://github.com/AquaticInformatics/eHSN-field-data-plugin/releases/download/v19.2.22/EhsnPlugin.plugin) |
 
 ## Configuring the plugin
 
 The plugin can be configured via a [`Config.json`](./src/EhsnPlugin/Config.json) JSON document, to control the mapping of eHSN values to your AQTS app server.
+
+The configurable values include:
+- Parameter IDs, unit IDs, and monitoring method codes for various sensors
+- Configurable picklist values
 
 The JSON configuration is stored in different places, depending on the version of the plugin.
 
@@ -32,6 +36,20 @@ The JSON configuration is stored in different places, depending on the version o
 | --- | --- |
 | 20.2.x | Use the Settings page of the System Config app to change the settings.<br/><br/>**Group**: `FieldDataPluginConfig-EhsnPlugin`<br/>**Key**: `Config`<br/>**Value**: The entire contents of the Config.json file. If blank or omitted, the plugin's default [`Config.json`](./src/EhsnPlugin/Config.json) is used. |
 | 19.2.x | Read from the `Config.json` file in the plugin folder, at `%ProgramData%\Aquatic Informatics\AQUARIUS Server\FieldDataPlugins\EhsnPlugin\Config.json` |
+
+### Do I need to configure the plugin?
+
+Quite possibly not.
+
+The default behavoir of the EHSN plugin is to assume the same configuration as the WSC AQUARIUS Time Series system. If your agency uses the same settings as WSC, then you won't need to configure anything.
+
+If you install the EHSN plugin on your AQTS app server and can successfully import an EHSN XML file, then no configuration changes are needed.
+
+If an EHSN XML file fails to import into your AQTS app server, then some configuration changes will likely be required.
+
+The likely items which may need to be configured are:
+- [StageLoggerMethodCode](./src/EhsnPlugin/Config.json#L7) and [Voltage.SensorMethodCode](./src/EhsnPlugin/Config.json#L112)
+- `ParameterId` values for the [KnownSensors](./src/EhsnPlugin/Config.json#L28-L138) list.
 
 ## Building the plugin
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 image: Visual Studio 2017
 
+pull_requests:
+  do_not_increment_build_number: true
+
 platform: Any CPU
 configuration: Release
 

--- a/src/EhsnPlugin/EhsnPlugin.csproj
+++ b/src/EhsnPlugin/EhsnPlugin.csproj
@@ -35,8 +35,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FieldDataPluginFramework, Version=2.9.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\Aquarius.FieldDataFramework.20.2.0\lib\net472\FieldDataPluginFramework.dll</HintPath>
+    <Reference Include="FieldDataPluginFramework, Version=2.10.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.FieldDataFramework.20.3.7\lib\net472\FieldDataPluginFramework.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.1.1.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\packages\morelinq.3.1.1\lib\net451\MoreLinq.dll</HintPath>
@@ -97,7 +97,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions />
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)packages\Aquarius.FieldDataFramework.20.2.0\tools\PluginPackager.exe $(TargetPath) /OutputPath=$(ProjectDir)deploy\$(Configuration)\$(TargetName).plugin /Description="Imports eHSN XML files into AQTS field visits"
-$(SolutionDir)packages\Aquarius.FieldDataFramework.20.2.0\tools\PluginTester.exe /Plugin=$(TargetPath) /Data=$(SolutionDir)..\data\*.xml</PostBuildEvent>
+    <PostBuildEvent>$(SolutionDir)packages\Aquarius.FieldDataFramework.20.3.7\tools\PluginPackager.exe $(TargetPath) /OutputPath=$(ProjectDir)deploy\$(Configuration)\$(TargetName).plugin /Description="Imports eHSN XML files into AQTS field visits"
+$(SolutionDir)packages\Aquarius.FieldDataFramework.20.3.7\tools\PluginTester.exe /Plugin=$(TargetPath) /Data=$(SolutionDir)..\data\*.xml</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/EhsnPlugin/EhsnPlugin.csproj
+++ b/src/EhsnPlugin/EhsnPlugin.csproj
@@ -35,8 +35,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FieldDataPluginFramework, Version=2.3.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\Aquarius.FieldDataFramework.19.2.2\lib\net472\FieldDataPluginFramework.dll</HintPath>
+    <Reference Include="FieldDataPluginFramework, Version=2.9.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\Aquarius.FieldDataFramework.20.2.0\lib\net472\FieldDataPluginFramework.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.1.1.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\packages\morelinq.3.1.1\lib\net451\MoreLinq.dll</HintPath>
@@ -85,9 +85,9 @@
     <Compile Include="DataModel\Version.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Config.json">
+    <EmbeddedResource Include="Config.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    </EmbeddedResource>
     <None Include="packages.config" />
     <None Include="Readme.md" />
     <None Include="Schema\eHSN.xsd">
@@ -97,7 +97,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions />
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)packages\Aquarius.FieldDataFramework.19.2.2\tools\PluginPackager.exe $(TargetPath) /OutputPath=$(ProjectDir)deploy\$(Configuration)\$(TargetName).plugin /Description="Imports eHSN XML files into AQTS field visits"
-$(SolutionDir)packages\Aquarius.FieldDataFramework.19.2.2\tools\PluginTester.exe /Plugin=$(TargetPath) /Data=$(SolutionDir)..\data\*.xml</PostBuildEvent>
+    <PostBuildEvent>$(SolutionDir)packages\Aquarius.FieldDataFramework.20.2.0\tools\PluginPackager.exe $(TargetPath) /OutputPath=$(ProjectDir)deploy\$(Configuration)\$(TargetName).plugin /Description="Imports eHSN XML files into AQTS field visits"
+$(SolutionDir)packages\Aquarius.FieldDataFramework.20.2.0\tools\PluginTester.exe /Plugin=$(TargetPath) /Data=$(SolutionDir)..\data\*.xml</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/EhsnPlugin/packages.config
+++ b/src/EhsnPlugin/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.FieldDataFramework" version="20.2.0" targetFramework="net472" />
+  <package id="Aquarius.FieldDataFramework" version="20.3.7" targetFramework="net472" />
   <package id="morelinq" version="3.1.1" targetFramework="net472" />
   <package id="ServiceStack.Text" version="4.5.12" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net472" />

--- a/src/EhsnPlugin/packages.config
+++ b/src/EhsnPlugin/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.FieldDataFramework" version="19.2.2" targetFramework="net472" />
+  <package id="Aquarius.FieldDataFramework" version="20.2.0" targetFramework="net472" />
   <package id="morelinq" version="3.1.1" targetFramework="net472" />
   <package id="ServiceStack.Text" version="4.5.12" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net472" />


### PR DESCRIPTION
DO NOT MERGE YET! The changes won't work on any shipping AQTS version.

@yanxuYX I've raised this pull request to contain some changes that allow the eHSN plugin to take advantage of new AQTS 2020.2 features, to make the configuration easier by getting the `Config.json` document from a global setting in the database, instead of from the plugin folder on each app server.

Once [AQTS 2020.2](https://github.com/AquaticInformatics/aquarius-field-data-framework/tree/master/docs#aqts-20202---framework-version-29) ships (later in July), we can merge this and WSC and its partner organizations can start using the Settings tab of the System Config page to make any configuration changes (if needed).

### Changes to the `Config.json` loading logic

The only change I made was how the `Config.json` file is loaded.
- The `Config.json` file in the repo is now bundled as an embedded resource in the plugin DLL itself.
- If the **Group**=`FieldDataPluginConfig-EhsnPlugin` **Key**=`Config` global setting exists and is not empty, use its value as the `Config.json` document.
- Otherwise fallback to the embedded `Config.json` document in the DLL.

### Benefits for WSC

This change adds some benefits to WSC:
- You won't need to keep a duplicate Config.json file in sync on all 3 load-balanced app servers.
- You won't need direct file-system access to each of the app servers.

If fact, WSC won't need to set *any* global setting at all. Unless you manually add a **Group**=`FieldDataPluginConfig-EhsnPlugin` **Key**=`Config` setting, the plugin will just fallback to the embedded `Config.json`, which comes from this repo. This is essentially what is being done in the current 19.2 version.

### Benefits for other agencies

This change also adds some benefits to other Canadian agencies who are wanting to use EHSN files for some of their field data (BC, Manitoba, and Saskatchewan, I think). These customers all need some way to override the default `Config.json` settings if their configuration doesn't exactly match WSC's configuration.

Eg. BC may not use the [`VBLOGGER`](https://github.com/AquaticInformatics/eHSN-field-data-plugin/blob/master/src/EhsnPlugin/Config.json#L112) method code for voltage readings from their loggers, so they might need to change it so some other method code in their system.

With the updated 2020.2-compatible version of the EHSN plugin, BC could take the `Config.json` document and tweak it to match their configuration, all using the System Config page, and without requiring direct access to the app server's filesystem (which is tightly controlled).
