### PR TITLE
Feature/pf 1142 fix control condition mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Choose the appropriate version of the plugin for your AQTS app server.
 
 | AQTS Version | Latest compatible plugin Version |
 | --- | --- |
-| AQTS 2020.3+ | [v20.3.0](https://github.com/AquaticInformatics/eHSN-field-data-plugin/releases/download/v20.3.0/EhsnPlugin.plugin) |
+| AQTS 2020.3+ | [v20.3.1](https://github.com/AquaticInformatics/eHSN-field-data-plugin/releases/download/v20.3.1/EhsnPlugin.plugin) |
 | AQTS 2020.2<br/>AQTS 2020.1<br/>AQTS 2019.4<br/>AQTS 2019.3<br/>AQTS 2019.2 | [v19.2.26](https://github.com/AquaticInformatics/eHSN-field-data-plugin/releases/download/v19.2.26/EhsnPlugin.plugin) |
 
 ## Configuring the plugin
@@ -28,13 +28,13 @@ The plugin can be configured via a [`Config.json`](./src/EhsnPlugin/Config.json)
 
 The configurable values include:
 - Parameter IDs, unit IDs, and monitoring method codes for various sensors
-- Configurable picklist values
+- Configurable picklist values. Values can be mapped to either the `List Item ID` (eg. `"Ice": "IceCover"`) or the `List Item Name` (eg. `"Ice": "Ice - Cover"`).
 
 The JSON configuration is stored in different places, depending on the version of the plugin.
 
 | Version | Configuration location |
 | --- | --- |
-| 20.2.x | Use the Settings page of the System Config app to change the settings.<br/><br/>**Group**: `FieldDataPluginConfig-EhsnPlugin`<br/>**Key**: `Config`<br/>**Value**: The entire contents of the Config.json file. If blank or omitted, the plugin's default [`Config.json`](./src/EhsnPlugin/Config.json) is used. |
+| 20.2.x+ | Use the Settings page of the System Config app to change the settings.<br/><br/>**Group**: `FieldDataPluginConfig-Ehsn`<br/>**Key**: `Config`<br/>**Value**: The entire contents of the Config.json file. If blank or omitted, the plugin's default [`Config.json`](./src/EhsnPlugin/Config.json) is used. |
 | 19.2.x | Read from the `Config.json` file in the plugin folder, at `%ProgramData%\Aquatic Informatics\AQUARIUS Server\FieldDataPlugins\EhsnPlugin\Config.json` |
 
 ### Do I need to configure the plugin?
@@ -50,6 +50,7 @@ If an EHSN XML file fails to import into your AQTS app server, then some configu
 The likely items which may need to be configured are:
 - [StageLoggerMethodCode](./src/EhsnPlugin/Config.json#L7) and [Voltage.SensorMethodCode](./src/EhsnPlugin/Config.json#L112)
 - `ParameterId` values for the [KnownSensors](./src/EhsnPlugin/Config.json#L28-L138) list.
+- Picklist mappings for the [KnownControlConditions](./src/EhsnPlugin/Config.json#L9-L17) list.
 
 ## Building the plugin
 

--- a/src/EhsnPlugin/DataModel/ParsedEhsnLevelSurvey.cs
+++ b/src/EhsnPlugin/DataModel/ParsedEhsnLevelSurvey.cs
@@ -40,6 +40,9 @@ namespace EhsnPlugin.DataModel
 
         public static string SanitizeBenchmarkName(string value)
         {
+            if (string.IsNullOrEmpty(value))
+                return value;
+
             if (value.StartsWith(PrimaryPrefix))
                 return value.Substring(PrimaryPrefix.Length).Trim();
 

--- a/src/EhsnPlugin/Mappers/DischargeActivityMapper.cs
+++ b/src/EhsnPlugin/Mappers/DischargeActivityMapper.cs
@@ -147,7 +147,9 @@ namespace EhsnPlugin.Mappers
 
             if (isAverage)
             {
-                var meanGageHeight = gageHeightMeasurements.Average(ghm => ghm.GageHeight.Value);
+                var meanGageHeight = gageHeightMeasurements
+                    .Where(ghm => ghm.Include)
+                    .Average(ghm => ghm.GageHeight.Value);
 
                 isAverage = stageMeasurementSummary.CorrectedMeanGageHeight.ToString("F3").Equals(meanGageHeight.ToString("F3"));
             }

--- a/src/EhsnPlugin/Mappers/FieldVisitMapper.cs
+++ b/src/EhsnPlugin/Mappers/FieldVisitMapper.cs
@@ -243,9 +243,9 @@ namespace EhsnPlugin.Mappers
 
             if (!string.IsNullOrWhiteSpace(conditionTypeText))
             {
-                if (Config.KnownControlConditions.ContainsKey(conditionTypeText))
+                if (Config.KnownControlConditions.TryGetValue(conditionTypeText, out var controlConditionValue))
                 {
-                    controlCondition.ConditionType = new ControlConditionPickList(conditionTypeText);
+                    controlCondition.ConditionType = new ControlConditionPickList(controlConditionValue);
                 }
                 else
                 {


### PR DESCRIPTION
@yanxuYX These 3 issues have come up as Manitoba has been testing the EHSN plugin with their system. I'll merge it once you've had a change to take a look.

1) 3d5f3eb - Fixes a bug where the `KnownControlConditions` configuration mapping wasn't actually taking effect.

This meant that Manitoba couldn't map "Ice" measurements to one of their own definitions for control conditions. Now the mapping configured in the JSON will actually take effect.

2) b164eda - Fixes a bug where the average gage height calculation was still influenced by explicitly ignored measurements.

Now the weighted MGH calculation should match the values calculated by the EHSN python program.

3) d88641a - This fixed a NullReferenceException when a level check summary row had a null `Reference` name

I was seeing a stack trace using one of the supplied files, so I fixed the bug.