### PR TITLE
Updates for eHSN 2.4

### DIFF
--- a/src/EhsnPlugin/Config.cs
+++ b/src/EhsnPlugin/Config.cs
@@ -6,7 +6,7 @@ namespace EhsnPlugin
     public class Config
     {
         public string MinVersion { get; set; } = "v1.3";
-        public string MaxVersion { get; set; } = "v2.3.3";
+        public string MaxVersion { get; set; } = "v2.4.3";
         public string DefaultChannelName { get; set; } = ChannelMeasurementBaseConstants.DefaultChannelName;
         public string UnknownMeterPlaceholder { get; set; } = "Unknown";
         public string StageWaterLevelMethodCode { get; set; }

--- a/src/EhsnPlugin/Config.json
+++ b/src/EhsnPlugin/Config.json
@@ -1,6 +1,6 @@
 ﻿{
   "MinVersion": "v1.3",
-  "MaxVersion": "v2.3.3",
+  "MaxVersion": "v2.4.3",
   "DefaultChannelName": "Main",
   "UnknownMeterPlaceholder": "Unknown",
   "StageWaterLevelMethodCode": "HGDWL",

--- a/src/EhsnPlugin/Mappers/DischargeActivityMapper.cs
+++ b/src/EhsnPlugin/Mappers/DischargeActivityMapper.cs
@@ -266,7 +266,25 @@ namespace EhsnPlugin.Mappers
         }
 
         private OtherDischargeSection CreateOtherMeasurement(DischargeActivity dischargeActivity, double discharge)
-        {
+        {   
+            var innovTechResults = new List<string>();
+            var innovTechRows = _ehsn.InnovTech?.InnovTechTable ?? Array.Empty<EHSNInnovTechTableRow>();
+            foreach (var row in innovTechRows)
+            {
+                if (!string.IsNullOrEmpty(row.text))
+                {
+                    innovTechResults.Add(row.label);
+                    innovTechResults.Add(row.text);
+                    innovTechResults.Add("-----");
+                }
+            }
+            var innovTechComment = _ehsn.InnovTech?.notes ?? string.Empty;
+            if (!string.IsNullOrEmpty(innovTechComment))
+            {
+                innovTechResults.Add("Comment:");
+                innovTechResults.Add(innovTechComment);
+            }
+
             return new OtherDischargeSection(
                 dischargeActivity.MeasurementPeriod,
                 Config.DefaultChannelName,
@@ -283,7 +301,8 @@ namespace EhsnPlugin.Mappers
                     {
                     _ehsn.InstrumentDeployment?.GeneralInfo?.position,
                     _ehsn.InstrumentDeployment?.GeneralInfo?.gauge1
-                    }.Where(s => !string.IsNullOrWhiteSpace(s)))
+                    }.Where(s => !string.IsNullOrWhiteSpace(s))),
+                    "+++++++++", string.Join("\n", innovTechResults)
                 }.Where(s => !string.IsNullOrWhiteSpace(s)))
             };
         }

--- a/src/EhsnPlugin/Mappers/FieldVisitMapper.cs
+++ b/src/EhsnPlugin/Mappers/FieldVisitMapper.cs
@@ -206,6 +206,12 @@ namespace EhsnPlugin.Mappers
             if (_eHsn.EnvCond?.downloadedData.ToBoolean() ?? false)
                 AddCommentLine(stringBuilder, "Downloaded Data", $"From {_eHsn.EnvCond?.dataPeriodStart} To {_eHsn.EnvCond?.dataPeriodEnd}");
 
+            if (_eHsn.EnvCond?.harnessAssessment.ToBoolean() ?? false)
+                AddCommentLine(stringBuilder, "Pre-Use Harness Assessment", string.Empty);
+
+            if (_eHsn.EnvCond?.cablewayAssessment.ToBoolean() ?? false)
+                AddCommentLine(stringBuilder, "Pre-Use Cableway Assessment", string.Empty);
+
             AddCommentLine(stringBuilder, "Stage Activity Summary Remarks", _eHsn.StageMeas?.stageRemark);
             AddCommentLine(stringBuilder, "Field Review Site Notes", _eHsn.FieldReview?.siteNotes);
             AddCommentLine(stringBuilder, "Field Review Plan Notes", _eHsn.FieldReview?.planNotes);

--- a/src/EhsnPlugin/Schema/eHSN.cs
+++ b/src/EhsnPlugin/Schema/eHSN.cs
@@ -44,6 +44,8 @@ public partial class EHSN {
     
     private EHSNFieldReview fieldReviewField;
 
+    private EHSNInnovTech innovTechField;
+    
     private EHSNMovingBoatMeas movingBoatMeasField;
     
     private EHSNMidsecMeas midsecMeasField;
@@ -152,6 +154,16 @@ public partial class EHSN {
         }
     }
 
+    /// <remarks/>
+    public EHSNInnovTech InnovTech {
+        get {
+            return this.innovTechField;
+        }
+        set {
+            this.innovTechField = value;
+        }
+    }
+    
     /// <remarks/>
     public EHSNMovingBoatMeas MovingBoatMeas {
         get {
@@ -3178,6 +3190,123 @@ public partial class EHSNFieldReviewFieldReviewTableRow {
         }
         set {
             this.reviewedField = value;
+        }
+    }
+    
+    /// <remarks/>
+    public string text {
+        get {
+            return this.textField;
+        }
+        set {
+            this.textField = value;
+        }
+    }
+    
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public byte row {
+        get {
+            return this.rowField;
+        }
+        set {
+            this.rowField = value;
+        }
+    }
+}
+
+/// <remarks/>
+[System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.7.3081.0")]
+[System.SerializableAttribute()]
+[System.Diagnostics.DebuggerStepThroughAttribute()]
+[System.ComponentModel.DesignerCategoryAttribute("code")]
+[System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true)]
+public partial class EHSNInnovTech {
+        
+    private string dependencyTypeField;
+    
+    private string monitoringTypeField;
+    
+    private EHSNInnovTechTableRow[] innovTechTableField;
+    
+    private string notesField;
+
+    private string emptyField;
+    
+    /// <remarks/>
+    public string dependencyType {
+        get {
+            return this.dependencyTypeField;
+        }
+        set {
+            this.dependencyTypeField = value;
+        }
+    }
+    
+    /// <remarks/>
+    public string monitoringType {
+        get {
+            return this.monitoringTypeField;
+        }
+        set {
+            this.monitoringTypeField = value;
+        }
+    }
+    
+    /// <remarks/>
+    [System.Xml.Serialization.XmlArrayItemAttribute("InnovTechTableRow", IsNullable=false)]
+    public EHSNInnovTechTableRow[] InnovTechTable {
+        get {
+            return this.innovTechTableField;
+        }
+        set {
+            this.innovTechTableField = value;
+        }
+    }
+    
+    /// <remarks/>
+    public string notes {
+        get {
+            return this.notesField;
+        }
+        set {
+            this.notesField = value;
+        }
+    }
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public string empty {
+        get {
+            return this.emptyField;
+        }
+        set {
+            this.emptyField = value;
+        }
+    }
+}
+
+/// <remarks/>
+[System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.7.3081.0")]
+[System.SerializableAttribute()]
+[System.Diagnostics.DebuggerStepThroughAttribute()]
+[System.ComponentModel.DesignerCategoryAttribute("code")]
+[System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true)]
+public partial class EHSNInnovTechTableRow {
+    
+    private string labelField;
+    
+    private string textField;
+    
+    private byte rowField;
+    
+    /// <remarks/>
+    public string label {
+        get {
+            return this.labelField;
+        }
+        set {
+            this.labelField = value;
         }
     }
     

--- a/src/EhsnPlugin/Schema/eHSN.cs
+++ b/src/EhsnPlugin/Schema/eHSN.cs
@@ -43,7 +43,7 @@ public partial class EHSN {
     private EHSNLevelNotes levelNotesField;
     
     private EHSNFieldReview fieldReviewField;
-    
+
     private EHSNMovingBoatMeas movingBoatMeasField;
     
     private EHSNMidsecMeas midsecMeasField;
@@ -151,7 +151,7 @@ public partial class EHSN {
             this.fieldReviewField = value;
         }
     }
-    
+
     /// <remarks/>
     public EHSNMovingBoatMeas MovingBoatMeas {
         get {
@@ -1136,6 +1136,10 @@ public partial class EHSNEnvCond {
     private string downloadedProgramField;
     
     private string downloadedDataField;
+
+    private string harnessAssessmentField;
+
+    private string cablewayAssessmentField;
     
     private string dataPeriodStartField;
     
@@ -1400,6 +1404,26 @@ public partial class EHSNEnvCond {
         }
         set {
             this.downloadedDataField = value;
+        }
+    }
+
+    /// <remarks/>
+    public string harnessAssessment {
+        get {
+            return this.harnessAssessmentField;
+        }
+        set {
+            this.harnessAssessmentField = value;
+        }
+    }
+
+    /// <remarks/>
+    public string cablewayAssessment {
+        get {
+            return this.cablewayAssessmentField;
+        }
+        set {
+            this.cablewayAssessmentField = value;
         }
     }
     

--- a/src/EhsnPlugin/Schema/eHSN.xsd
+++ b/src/EhsnPlugin/Schema/eHSN.xsd
@@ -436,6 +436,31 @@
               </xs:sequence>
             </xs:complexType>
           </xs:element>
+          <xs:element name="InnovTech">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="dependencyType" type="xs:string" />
+                <xs:element name="monitoringType" type="xs:string" />
+                <xs:element name="InnovTechTable">
+                  <xs:complexType>
+                    <xs:sequence>
+                      <xs:element maxOccurs="unbounded" name="InnovTechTableRow">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="label" type="xs:string" />
+                            <xs:element name="text" type="xs:string" />
+                          </xs:sequence>
+                          <xs:attribute name="row" type="xs:unsignedByte" use="required" />
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="notes" type="xs:string" />
+              </xs:sequence>
+              <xs:attribute name="empty" type="xs:string" use="required" />
+            </xs:complexType>
+          </xs:element>
           <xs:element name="MovingBoatMeas">
             <xs:complexType>
               <xs:sequence>

--- a/src/EhsnPlugin/Schema/eHSN.xsd
+++ b/src/EhsnPlugin/Schema/eHSN.xsd
@@ -143,6 +143,8 @@
                 <xs:element name="orificePurged" type="xs:string" />
                 <xs:element name="downloadedProgram" type="xs:string" />
                 <xs:element name="downloadedData" type="xs:string" />
+                <xs:element name="harnessAssessment" type="xs:string" />
+                <xs:element name="cablewayAssessment" type="xs:string" />
                 <xs:element name="dataPeriodStart" type="xs:string" />
                 <xs:element name="dataPeriodEnd" type="xs:string" />
                 <xs:element name="stationHealthRemark" type="xs:string" />

--- a/src/EhsnPlugin/Validators/VersionValidator.cs
+++ b/src/EhsnPlugin/Validators/VersionValidator.cs
@@ -8,7 +8,7 @@ namespace EhsnPlugin.Validators
         private Version MinVersion { get; } = DefaultVersion;
         private Version MaxVersion { get; } = DefaultVersion;
 
-        private static readonly Version DefaultVersion = Version.Create("v2.3.3");
+        private static readonly Version DefaultVersion = Version.Create("v2.4.3");
 
         public VersionValidator(Config config)
         {


### PR DESCRIPTION
Updates to match upcoming eHSN version release:
- Increased max version number to v.2.4.3
- Added checkboxes for Pre-Use Harness Assessment and Pre-Use Cableway Assessment
- Added new text table and comment field for InnovTech and mapped these values into the OtherDischargeSection comment

I developed these changes while working at WSC alongside @yanxuYX.